### PR TITLE
Make unicode checkmarks optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ project(rsgain
   HOMEPAGE_URL "https://github.com/complexlogic/rsgain"
   LANGUAGES CXX
 )
+
+option(UCHECKMARKS "Enable use of Unicode checkmarks" ON)
+
 set(CMAKE_CXX_STANDARD 20)
 set(EXECUTABLE_TITLE "rsgain")
 include_directories(${PROJECT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,9 @@ if (WIN32)
 
 elseif (UNIX)
   add_executable(${EXECUTABLE_TITLE} ${SOURCE_FILES})
+  if(NOT UCHECKMARKS)
+    target_compile_definitions(${EXECUTABLE_TITLE} PUBLIC "NOUCHECKMARKS")
+  endif()
   target_link_libraries(${EXECUTABLE_TITLE}
     PkgConfig::LIBAVFORMAT
     PkgConfig::LIBAVCODEC

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -50,7 +50,8 @@
 #define COLOR_OFF	"[0m"
 
 // The default Windows console font doesn't support the ✔ and ✘ characters
-#ifdef _WIN32
+// and make it optional by defining NOUCHECKMARKS
+#if defined _WIN32 || defined NOUCHECKMARKS
 #define OK_CHAR "OK"
 #define ERROR_CHAR "ERROR"
 #define FAIL_CHAR "FAILURE"


### PR DESCRIPTION
This is troublesome using PuTTY and various others console renders so make it optional and fall back to text output. Define NOUCHECKMARKS to to use text output instead.