### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -28,7 +28,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <string.h>
 #include <string>


### PR DESCRIPTION
error: no member named 'round' in namespace 'std'