### PR TITLE
Add support for malformed Windows OS file extensions

### DIFF
--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -81,7 +81,9 @@ static FileType determine_filetype(const std::string &extension)
         {".ape",  FileType::APE},
         {".mpc",  FileType::MPC}
     };
-    auto it = map.find(extension);
+	std::string extensionlower = extension;
+	std::transform(extensionlower.begin(), extensionlower.end(), extensionlower.begin(), ::tolower);
+    auto it = map.find(extensionlower);
     return it == map.end() ? FileType::INVALID : it->second;
 }
 


### PR DESCRIPTION
Windows file systems are case insensitive. Because of this in large archives you can often find some extensions that are in the wrong case and totally valid from an OS perspective. Just adding a quick tolower on the extension before the check. Casting to a new var to keep the original as a constant, but can rewrite if you wish.

I thought this sort of behaviour was appropriate for the "easy" mode provided by the program. It's a design philosophy I like. It's best to not have malformed file extensions but a novice might have a few it's understandable. They might not even have file extensions set to visible in Windows which would cause some frustration trying to figure out what the problem is.
 
![proof](https://user-images.githubusercontent.com/10760232/231984669-0dde3326-6daa-432a-8d05-1dfe73935a7b.png)
