### PR TITLE
Fix docker build broken by debian bookworm release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:bullseye
 
 ARG VERSION=3.3 \
     ARCH=amd64


### PR DESCRIPTION
Hi!

Since the `debian` image got updated to `bookworm`, the dependencies of v3.3 are not compatible with it anymore:

```
The following packages have unmet dependencies:
 rsgain : Depends: libavcodec58 (>= 4.2.4) but it is not installable
          Depends: libavutil56 (>= 4.2.4) but it is not installable
          Depends: libswresample3 (>= 4.2.4) but it is not installable
          Depends: libavformat58 (>= 4.2.4) but it is not installable
```

As a simple workaround I've updated the `Dockerfile` to be explicitly based on `bullseye` (presumably until a build is made for `bookworm`, but the wonder of docker is that it is not an immediate worry).

Cheers!