### PR TITLE
Support for Tom's lossless Audio Kompressor (.tak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ rsgain supports all popular file formats. See the below table for compatibility.
 | Musepack (MPC)²                      | .mpc                        |
 | Ogg (Vorbis, Speex, FLAC)            | .ogg, .oga, .spx            |
 | Opus                                 | .opus                       |
+| Tom's lossless Audio Kompressor      | .tak                        |
 | Waveform Audio File Format (WAV)     | .wav                        |
 | Wavpack                              | .wv                         |
 | Windows Media Audio (WMA)            | .wma                        |

--- a/config/presets/default.ini
+++ b/config/presets/default.ini
@@ -108,6 +108,14 @@ OpusMode=d
 #MaxPeakLevel=0.0
 #TruePeak=false
 
+[TAK]
+#TagMode=i
+#Album=true
+#TargetLoudness=-18
+#ClipMode=p
+#MaxPeakLevel=0.0
+#TruePeak=false
+
 [Musepack]
 #TagMode=i
 #Album=true

--- a/config/presets/ebur128.ini
+++ b/config/presets/ebur128.ini
@@ -108,6 +108,14 @@ OpusMode=d
 #MaxPeakLevel=-1.0
 #TruePeak=true
 
+[TAK]
+#TagMode=i
+#Album=true
+#TargetLoudness=-23
+#ClipMode=p
+#MaxPeakLevel=-1.0
+#TruePeak=true
+
 [Musepack]
 #TagMode=i
 #Album=true

--- a/config/presets/loudgain.ini
+++ b/config/presets/loudgain.ini
@@ -108,6 +108,14 @@ TargetLoudness=-23
 #MaxPeakLevel=-1.0
 #TruePeak=true
 
+[TAK]
+#TagMode=i
+#Album=true
+#TargetLoudness=-18
+#ClipMode=a
+#MaxPeakLevel=-1.0
+#TruePeak=true
+
 [Musepack]
 #TagMode=i
 #Album=true

--- a/config/presets/no_album.ini
+++ b/config/presets/no_album.ini
@@ -108,6 +108,14 @@ OpusMode=d
 #MaxPeakLevel=0.0
 #TruePeak=false
 
+[TAK]
+#TagMode=i
+#Album=true
+#TargetLoudness=-18
+#ClipMode=p
+#MaxPeakLevel=0.0
+#TruePeak=false
+
 [Musepack]
 #TagMode=i
 #Album=true

--- a/src/easymode.cpp
+++ b/src/easymode.cpp
@@ -245,6 +245,23 @@ static Config configs[] = {
         .opus_mode = 'd'
     },
 
+    // TAK config
+    {
+        .tag_mode = 'i',
+        .skip_existing = false,
+        .target_loudness = RG_TARGET_LOUDNESS,
+        .max_peak_level = 0.0,
+        .true_peak = false,
+        .clip_mode = 'p',
+        .do_album = true,
+        .tab_output = OutputType::NONE,
+        .sep_header = false,
+        .sort_alphanum = false,
+        .lowercase = false,
+        .id3v2version = 3,
+        .opus_mode = 'd'
+    },
+    
     // Musepack config
     {
         .tag_mode = 'i',
@@ -388,6 +405,7 @@ static FileType determine_section_type(const std::string &section)
         {"AIFF",     FileType::AIFF},
         {"Wavpack",  FileType::WAVPACK},
         {"APE",      FileType::APE},
+        {"TAK",      FileType::TAK},
         {"Musepack", FileType::MPC}
     };
     auto it = map.find(section);

--- a/src/rsgain.cpp
+++ b/src/rsgain.cpp
@@ -381,7 +381,7 @@ static void help_main() {
     fmt::print("{} {} supports writing tags to the following file types:\n", PROJECT_NAME, PROJECT_VERSION);
     fmt::print("  FLAC (.flac), Ogg (.ogg, .oga, .spx), Opus (.opus), MP2 (.mp2),\n");
     fmt::print("  MP3 (.mp3), MP4 (.m4a), WMA (.wma), WavPack (.wv), APE (.ape),\n");
-    fmt::print("  WAV (.wav), and AIFF (.aiff, .aif, .snd).\n");
+    fmt::print("  WAV (.wav), AIFF (.aiff, .aif, .snd), and TAK (.tak).\n");
 
     fmt::print("\n");
     fmt::print(COLOR_RED "Options:\n" COLOR_OFF);

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -80,6 +80,7 @@ static FileType determine_filetype(const std::string &extension)
         {".snd",  FileType::AIFF},
         {".wv",   FileType::WAVPACK},
         {".ape",  FileType::APE},
+        {".tak", FileType::APE},
         {".mpc",  FileType::MPC}
     };
 	std::string extensionlower = extension;

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -80,7 +80,7 @@ static FileType determine_filetype(const std::string &extension)
         {".snd",  FileType::AIFF},
         {".wv",   FileType::WAVPACK},
         {".ape",  FileType::APE},
-        {".tak", FileType::APE},
+        {".tak", FileType::TAK},
         {".mpc",  FileType::MPC}
     };
 	std::string extensionlower = extension;

--- a/src/scan.hpp
+++ b/src/scan.hpp
@@ -21,6 +21,7 @@ enum class FileType {
     AIFF,
     WAVPACK,
     APE,
+	TAK,
 	MPC
 };
 

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -284,8 +284,9 @@ bool tag_exists(const ScanJob::Track &track)
 
         case FileType::WAVPACK:
             return tag_exists_ape<TagLib::WavPack::File>(track);
-
+            
         case FileType::APE:
+        case FileType::TAK:
             return tag_exists_ape<TagLib::APE::File>(track);
 
         case FileType::MPC:

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -237,8 +237,9 @@ void tag_track(ScanJob::Track &track, const Config &config)
             if (!tag_apev2<TagLib::WavPack::File>(track, config))
                 tag_error(track);
             break;
-
+            
         case FileType::APE:
+        case FileType::TAK:
             if (!tag_apev2<TagLib::APE::File>(track, config))
                 tag_error(track);
             break;


### PR DESCRIPTION
[TAK](https://wiki.hydrogenaud.io/index.php?title=TAK) uses APEv2 for tagging and rsgain appears to handle it correctly (writing APE tags to the end of the file the same way Picard does) and non–destructively. 