### PR TITLE
Change scan log file extension to tsv

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ This feature merely checks for the *existence* of the tags, and does not verify 
 
 #### Logging
 
-You can use the `-O` option to enable scan logs. The program will save a tab-delimited file titled `replaygain.csv` with the scan results for every directory it scans. The log files can be viewed in a spreadsheet application.
+You can use the `-O` option to enable scan logs. The program will save a tab-delimited file titled `replaygain.tsv` with the scan results for every directory it scans. The log files can be viewed in a spreadsheet application.
 
 ##### Microsoft Excel
 
-Microsoft Excel doesn't recognize the tab delimiter in CSV files by default. To enable Excel compatibility, rsgain has an option `-Os` which will add a `sep` header to the CSV file. This is a non-standard Microsoft extension which will enable the outputted CSV files to open in Excel.
+Some versions of Microsoft Excel may fail to recognize the tab delimiter in TSV files by default. To enable Excel compatibility, rsgain has an option `-Os` which will add a `sep` header to the TSV file. This is a non-standard Microsoft extension which will enable the outputted TSV files to open in Excel.
 
 ##### Sorting
 

--- a/docs/rsgain.1
+++ b/docs/rsgain.1
@@ -74,7 +74,7 @@ Scan files with \fBn\fR parallel threads\.
 Load scan preset \fBs\fR\.
 .TP
 \fB\-O\fR, \fB\-\-output\fR
-Output tab\-delimited scan data to CSV file per directory\.
+Output tab\-delimited scan data to TSV file per directory\.
 .TP
 \fB\-O s\fR, \fB\-\-output=s\fR
 Output with sep header (needed for Microsoft Excel compatibility)\.

--- a/src/easymode.cpp
+++ b/src/easymode.cpp
@@ -833,7 +833,7 @@ static inline void help_easy() {
 
     print("\n");
 
-    CMD_HELP("--output", "-O",  "Output tab-delimited scan data to CSV file per directory");
+    CMD_HELP("--output", "-O",  "Output tab-delimited scan data to TSV file per directory");
     CMD_HELP("--output=s", "-O s",  "Output with sep header (needed for Microsoft Excel compatibility)");
     CMD_HELP("--output=a", "-O a",  "Output with files sorted in alphanumeric order");
 

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -495,7 +495,7 @@ void ScanJob::tag_tracks()
     std::FILE *stream = nullptr;
     if (config.tab_output != OutputType::NONE) {
         if (config.tab_output == OutputType::FILE) {
-            std::filesystem::path output_file = std::filesystem::path(path) / "replaygain.csv";
+            std::filesystem::path output_file = std::filesystem::path(path) / "replaygain.tsv";
             stream = fopen(output_file.string().c_str(), "wb");
         }
         else


### PR DESCRIPTION
This extension accurately represents the format of the file, which is TSV (tab-separated values) as opposed to CSV (comma-separated values).

It seems likely that this would address #56 without the need for 6402b2b.