### PR TITLE
Change install instructions for Fedora to use repository instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ yay -S rsgain
 
 #### Fedora
 
-A package is available on the [release page](https://github.com/complexlogic/rsgain/releases/latest) that is compatible with Fedora 39.
+rsgain is packaged in Fedora's repositories. You can use `dnf` to install:
 
 ```bash
-sudo dnf install https://github.com/complexlogic/rsgain/releases/download/v3.5/rsgain-3.5-1.x86_64.rpm
+sudo dnf install rsgain
 ```
 
 #### Nix/NixOS


### PR DESCRIPTION
rsgain has been packaged since Fedora 38:
https://packages.fedoraproject.org/pkgs/rsgain/rsgain/

This makes it easier for users to install.