### PR TITLE
rsgain.cpp: use C++ cmath

### DIFF
--- a/src/rsgain.cpp
+++ b/src/rsgain.cpp
@@ -33,8 +33,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 #include <getopt.h>
+#include <cmath>
 #include <string>
 #include <locale>
 
@@ -150,7 +150,7 @@ bool parse_max_peak_level(const char *value, double &peak)
 {
     char *rest = nullptr;
     double max_peak = strtod(value, &rest);
-    if (rest == value || !isfinite(max_peak)) {
+    if (rest == value || !std::isfinite(max_peak)) {
         output_error("Invalid max peak level '{}'", value);
         return false;
     }


### PR DESCRIPTION
Current code uses C99 header and `isfinite` in C++ file, which fails to compile on some configs. Fix that.